### PR TITLE
Replace unused init list with comma operator

### DIFF
--- a/src/input/CSVReader.h
+++ b/src/input/CSVReader.h
@@ -96,7 +96,7 @@ private:
      * https://stackoverflow.com/questions/34314806/parsing-a-c-string-into-a-tuple [accessed 29.06.2021]
      */
     template<typename Tuple, typename std::size_t... I>
-    void getTuple(std::istream &lineStream, Tuple &tuple, std::index_sequence<I...>) {
+    void getTuple(std::istream &lineStream, Tuple &tuple, std::index_sequence<I...>) const {
       (parseCell(lineStream, std::get<I>(tuple)), ...);
     }
 


### PR DESCRIPTION
Not sure if I really understand this line but compilers complain that this initializer list is unused.
As far as I can see, you only use the initializer list as a means to repeatedly call the function within. This could also be done via the [comma operator](https://en.cppreference.com/w/cpp/language/operator_other).

Check whether this patch actually does what you need it to do!