### PR TITLE
TLE Epoche & Mass Conservation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ target_link_libraries(${PROJECT_NAME}_lib
         )
 
 if (NOT CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-    message("-- Linking tbb libary")
+    message(STATUS "Linking tbb libary")
     target_link_libraries(${PROJECT_NAME}_lib
             tbb)
 endif()

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The given yaml-file should look like this:
     idFilter: [1, 2]                  #Only the satellites with these IDs will be
                                       #recognized by the simulation.
                                       #If not given, no filter is applied
-    enforceMassConservation: True     #When this is et to true, the simulation will
+    enforceMassConservation: True     #When this is set to true, the simulation will
                                       #try to enforce mass conservation
                                       #if not given, this is always false
   inputOutput:                        #If you want to print out the input data into specific file (optional)

--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ can be found in the folder example-config of this repository.
   - The simulation does produce the debris according to power law distribution
   - If this is enabled more fragments than specified for the minimal L_c will be
     produced if the former simulation ended with outputMass < inputMass
+  - **Caution!** The filling of the mass budget is not always reasonable! E.g. In case
+    of a non-catastrophic collision the bigger object is NOT fully fragmented,
+    hence a fulfilling inputMass == outputMass in the end is not desirable!
   - Notice that to maintain the correct distribution, outputMass == inputMass will
     not be produced but approximated
   - Notice that the case outputMass > inputMass is not affected by this option;
@@ -184,6 +187,7 @@ it produces both, either of them or none (see YAML Configuration File)
 | A       | Area [m^2]                | M       | Mean Anomaly [rad] |
 | m       | Mass [kg]                 | E       | Eccentric Anomaly [rad] |
 | v       | Velocity [m/s]            | T       | True Anomaly [rad] |
+| j       | Ejection Velocity [m/s]   |         | |
 | p       | Position [m]              |         | |
 
 ## Library

--- a/README.md
+++ b/README.md
@@ -36,6 +36,40 @@ After the build, the simulation can be run by executing:
 
 where the yaml-file contains a Configuration.
 
+### Brief overview on the available options
+
+- _minimalCharacteristicLength_
+  - The simulation will only produce fragments greater than this lower bound
+  - Usefully because, real radar detection does not allow us to track infinitesimal
+    small particles in space
+  - Set this to reasonable values, small values will lead to lots of debris!
+- _simulationType_
+  - OPTIONAL 
+  - Acts like a guard to protect the user from running an undesired simulation
+  - Ensures Mode: COLLISION or EXPLOSION
+- _currentMaxID_
+  - OPTIONAL
+  - The debris fragments will have unique IDs, this option should contain the
+    currently highest NORAD Catalog ID
+  - If not given the Simulation tries to derive the current highest ID from
+    the given input
+- _inputSource_
+  - Takes the input data as a list: Either Data-YAML file or TLE + Satcat
+- _idFilter_
+  - OPTIONAL
+  - Applies a filter over the inputSource
+  - Useful if you give the full Satcat + TLE data and don't want to manually
+    extract the Satellites which should collide or similar
+- _enforceMassConservation_
+  - OPTIONAL (default false)
+  - The simulation does produce the debris according to power law distribution
+  - If this is enabled more fragments than specified for the minimal L_c will be
+    produced if the former simulation ended with outputMass < inputMass
+  - Notice that to maintain the correct distribution, outputMass == inputMass will
+    not be produced but approximated
+  - Notice that the case outputMass > inputMass is not affected by this option;
+    the removal of a mass excess is always applied
+
 ### Input
 
 The given yaml-file should look like this:
@@ -47,6 +81,7 @@ The given yaml-file should look like this:
                                       #If not given type is determined
                                       # by number of input satellites 
     currentMaxID: 48514               #For determining fragment ID
+                               
                                       #Should be the currently largest given NORAD-Catalog ID
                                       #If not given, zero is assumed
     inputSource: ["../data.yaml"]     #Path to input file(s) - One of the following:
@@ -55,6 +90,9 @@ The given yaml-file should look like this:
     idFilter: [1, 2]                  #Only the satellites with these IDs will be
                                       #recognized by the simulation.
                                       #If not given, no filter is applied
+    enforceMassConservation: True     #When this is et to true, the simulation will
+                                      #try to enforce mass conservation
+                                      #if not given, this is always false
   inputOutput:                        #If you want to print out the input data into specific file (optional)
     target: ["input.csv", "input.vtu"]#Target files
     #kepler: True                     #CSV with Kepler elements

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ where the yaml-file contains a Configuration.
     not be produced but approximated
   - Notice that the case outputMass > inputMass is not affected by this option;
     the removal of a mass excess is always applied
+  - Notice that this option kills some performance because of the random nature, there
+    is no possibility to schedule how many particles will be produced in the end
 
 ### Input
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ After the build, the simulation can be run by executing:
 
     ./breakupModel [yaml-file]
 
-where the yaml-file contains a Configuration.
+where the yaml-file contains a Configuration. Examples for Configuration Files
+can be found in the folder example-config of this repository.
 
 ### Brief overview on the available options
 

--- a/example-config/config_bess2.yaml
+++ b/example-config/config_bess2.yaml
@@ -1,0 +1,13 @@
+---
+simulation:
+  minimalCharacteristicLength: 0.0001
+  simulationType: COLLISION
+  inputSource: ["../example-config/data_bess2.yaml"]
+inputOutput:
+  target: ["input.csv", "input.vtu"]
+  #kepler: True
+  #csvPattern: "IL"
+resultOutput:
+  target: ["result.csv", "result.vtu"]
+  #kepler: True
+  #csvPattern: "IL"

--- a/example-config/config_iridium_cosmos2.yaml
+++ b/example-config/config_iridium_cosmos2.yaml
@@ -11,3 +11,4 @@ inputOutput:
 resultOutput:
   target: ["result.csv", "result.vtu"]
   kepler: True
+  # csvPattern: "IntLRAmvjpaeiWwM"

--- a/example-config/data_bess2.yaml
+++ b/example-config/data_bess2.yaml
@@ -1,0 +1,13 @@
+---
+#List of satellites
+satellites:
+  - name: "Target"
+    id: 1
+    satType: SPACECRAFT
+    mass: 100.0
+    velocity: [0, 0.0, 0.0]
+  - name: "Projectile"
+    id: 2
+    satType: SPACECRAFT
+    mass: 0.00037
+    velocity: [4500, 0.0, 0.0]

--- a/src/breakupModel/input/InputConfigurationSource.h
+++ b/src/breakupModel/input/InputConfigurationSource.h
@@ -87,6 +87,6 @@ public:
      * of additional fragments if the mass budget was not yet exceeded (after the normal run)
      * @return a bool
      */
-    virtual bool getEnforcedMassConservation() const = 0;
+    virtual bool getEnforceMassConservation() const = 0;
 
 };

--- a/src/breakupModel/input/InputConfigurationSource.h
+++ b/src/breakupModel/input/InputConfigurationSource.h
@@ -82,4 +82,11 @@ public:
      */
     virtual std::optional<std::set<size_t>> getIDFilter() const = 0;
 
+    /**
+     * Returns a bool which states if the simulation should enforce the mass conservation through the generation
+     * of additional fragments if the mass budget was not yet exceeded (after the normal run)
+     * @return a bool
+     */
+    virtual bool getEnforcedMassConservation() const = 0;
+
 };

--- a/src/breakupModel/input/RuntimeInputSource.cpp
+++ b/src/breakupModel/input/RuntimeInputSource.cpp
@@ -25,6 +25,6 @@ std::vector<Satellite> RuntimeInputSource::getSatelliteCollection() const {
     return _satellites;
 }
 
-bool RuntimeInputSource::getEnforcedMassConservation() const {
+bool RuntimeInputSource::getEnforceMassConservation() const {
     return _enforceMassConservation;
 }

--- a/src/breakupModel/input/RuntimeInputSource.cpp
+++ b/src/breakupModel/input/RuntimeInputSource.cpp
@@ -24,3 +24,7 @@ std::optional<std::set<size_t>> RuntimeInputSource::getIDFilter() const {
 std::vector<Satellite> RuntimeInputSource::getSatelliteCollection() const {
     return _satellites;
 }
+
+bool RuntimeInputSource::getEnforcedMassConservation() const {
+    return _enforceMassConservation;
+}

--- a/src/breakupModel/input/RuntimeInputSource.h
+++ b/src/breakupModel/input/RuntimeInputSource.h
@@ -109,5 +109,5 @@ public:
 
     std::vector<Satellite> getSatelliteCollection() const final;
 
-    bool getEnforcedMassConservation() const final;
+    bool getEnforceMassConservation() const final;
 };

--- a/src/breakupModel/input/RuntimeInputSource.h
+++ b/src/breakupModel/input/RuntimeInputSource.h
@@ -19,6 +19,8 @@ class RuntimeInputSource
 
     const std::optional<std::set<size_t>> _idFilter{std::nullopt};
 
+    const bool _enforceMassConservation{false};
+
     const std::vector<Satellite> _satellites;
 
 public:
@@ -40,33 +42,37 @@ public:
      * @param simulationType - type of simulation --> strong definition, error handling possible
      * @param currentMaximalGivenId - maximal given NORAD Catalog ID
      * @param idFilter - filter which satellites to use
+     * @param enforceMassConservation - should the input mass always equals the output mass (default: false)
      */
     RuntimeInputSource(double minimalCharacteristicLength, std::vector<Satellite> satellites,
                        SimulationType simulationType, size_t currentMaximalGivenId,
-                       std::optional<std::set<size_t>> idFilter)
+                       std::optional<std::set<size_t>> idFilter, bool enforceMassConservation = false)
             : _minimalCharacteristicLength{minimalCharacteristicLength},
               _satellites{std::move(satellites)},
               _simulationType{simulationType},
               _currentMaximalGivenID{std::make_optional(currentMaximalGivenId)},
-              _idFilter{std::move(idFilter)} {}
+              _idFilter{std::move(idFilter)},
+              _enforceMassConservation{enforceMassConservation} {}
 
 
     /**
-     * Constructs a new Runtime Source with all parameters available.
-     * @param minimalCharacteristicLength - double
-     * @param satellites - satellite vector
-     * @param simulationType - type of simulation --> strong definition, error handling possible
-     * @param currentMaximalGivenId - maximal given NORAD Catalog ID
-     * @param idFilter - filter which satellites to use
-     */
+    * Constructs a new Runtime Source with all parameters available.
+    * @param minimalCharacteristicLength - double
+    * @param satellites - satellite vector
+    * @param simulationType - type of simulation --> strong definition, error handling possible
+    * @param currentMaximalGivenId - maximal given NORAD Catalog ID
+    * @param idFilter - filter which satellites to use
+    * @param enforceMassConservation - should the input mass always equals the output mass (default: false)
+    */
     RuntimeInputSource(double minimalCharacteristicLength, std::vector<Satellite> satellites,
                        SimulationType simulationType, std::optional<size_t> currentMaximalGivenId,
-                       std::optional<std::set<size_t>> idFilter)
+                       std::optional<std::set<size_t>> idFilter, bool enforceMassConservation = false)
             : _minimalCharacteristicLength{minimalCharacteristicLength},
               _satellites{std::move(satellites)},
               _simulationType{simulationType},
               _currentMaximalGivenID{currentMaximalGivenId},
-              _idFilter{std::move(idFilter)} {}
+              _idFilter{std::move(idFilter)},
+              _enforceMassConservation{enforceMassConservation} {}
 
 
     /**
@@ -78,15 +84,17 @@ public:
      * @param simulationType - type of simulation --> strong definition, error handling possible
      * @param currentMaximalGivenId - maximal given NORAD Catalog ID
      * @param idFilter - filter which satellites to use
+     * @param enforceMassConservation - should the input mass always equals the output mass (default: false)
      */
     RuntimeInputSource(double minimalCharacteristicLength, const std::shared_ptr<const DataSource> &dataSource,
                        SimulationType simulationType, size_t currentMaximalGivenId,
-                       std::optional<std::set<size_t>> idFilter)
+                       std::optional<std::set<size_t>> idFilter, bool enforceMassConservation = false)
             : _minimalCharacteristicLength{minimalCharacteristicLength},
               _satellites{dataSource->getSatelliteCollection()},
               _simulationType{simulationType},
               _currentMaximalGivenID{std::make_optional(currentMaximalGivenId)},
-              _idFilter{std::move(idFilter)} {}
+              _idFilter{std::move(idFilter)},
+              _enforceMassConservation{enforceMassConservation} {}
 
 
     double getMinimalCharacteristicLength() const final;
@@ -100,4 +108,6 @@ public:
     std::optional<std::set<size_t>> getIDFilter() const final;
 
     std::vector<Satellite> getSatelliteCollection() const final;
+
+    bool getEnforcedMassConservation() const final;
 };

--- a/src/breakupModel/input/TLEReader.cpp
+++ b/src/breakupModel/input/TLEReader.cpp
@@ -42,48 +42,67 @@ std::map<size_t, OrbitalElements> TLEReader::getMappingIDOrbitalElements() const
     std::map<size_t, OrbitalElements> mapping{};
 
     std::ifstream fileStream{_filepath};
+    std::string line;
+    std::string line1;
     std::string line2;
 
-    while (std::getline(fileStream, line2)) {
-        if (line2.rfind('2', 0) == 0) {
-            auto pair = parseLineTwo(line2);
+    bool line1Found = false;
+
+    while (std::getline(fileStream, line)) {
+        if (line.rfind('1', 0) == 0) {
+            line1 = line;
+            line1Found = true;
+        } else if (line.rfind('2', 0) == 0 && line1Found) {
+            line2 = line;
+            auto pair = parseLineTwo(line1, line2);
             mapping.insert(pair);
+            line1Found = false;
         }
     }
 
     return mapping;
 }
 
-std::pair<size_t, OrbitalElements> TLEReader::parseLineTwo(const std::string &line) const {
+std::pair<size_t, OrbitalElements> TLEReader::parseLineTwo(const std::string &line1, const std::string &line2) const {
     size_t id;
     std::array<double, 6> tleData{};
+    int year;
+    double fraction;
 
     try {
         //ID
-        char firstCharOfID = line.at(2);
-        std::string restID = line.substr(3, 4);
+        char firstCharOfID = line2.at(2);
+        std::string restID = line2.substr(3, 4);
         id = std::stoul(restID);
         id += alpha5NumberingSchemeOffset.at(firstCharOfID);
         //Mean Motion [rev/day]
-        tleData[0] = std::stod(line.substr(52, 11));
+        tleData[0] = std::stod(line2.substr(52, 11));
         //Eccentricity
-        tleData[1] = std::stod("0." + line.substr(26, 7));
+        tleData[1] = std::stod("0." + line2.substr(26, 7));
         //Inclination [deg]
-        tleData[2] = std::stod(line.substr(8, 8));
+        tleData[2] = std::stod(line2.substr(8, 8));
         //RAAN [deg]
-        tleData[3] = std::stod(line.substr(17, 8));
+        tleData[3] = std::stod(line2.substr(17, 8));
         //Argument of Perigee [deg]
-        tleData[4] = std::stod(line.substr(34, 8));
+        tleData[4] = std::stod(line2.substr(34, 8));
         //Mean Anomaly [deg]
-        tleData[5] = std::stod(line.substr(43, 8));
+        tleData[5] = std::stod(line2.substr(43, 8));
+
+        //The year
+        year = std::stoi(line1.substr(18, 2));
+        year = year < 57 ? year + 2000 : year + 1900;
+        //The fraction of the year
+        fraction = std::stod(line1.substr(20, 8));
+
     } catch (std::exception &e) {
         throw std::runtime_error{"The TLE file \"" + _filepath +
                                  "\" is malformed! Some Data could not be parsed correctly into valid numbers!\n"
                                  "The issue appeared in the following line:\n"
-                                 + line
+                                 + line1
         };
     }
 
     OrbitalElementsFactory factory{};
-    return std::make_pair(id, factory.createFromTLEData(tleData));
+    Epoch epoch{year, fraction};
+    return std::make_pair(id, factory.createFromTLEData(tleData, epoch));
 }

--- a/src/breakupModel/input/TLEReader.h
+++ b/src/breakupModel/input/TLEReader.h
@@ -55,11 +55,11 @@ private:
 
     /**
      * Parses the line two of an TLE entry to a pair of ID and Kepler elements.
-     * @param line - the input stream
+     * @param line1 - the input stream
      * @return a pair of ID and KeplerElements
      * @throws an exception if the TLE is malformed or any other issues are encountered during the parsing
      */
-    std::pair<size_t, OrbitalElements> parseLineTwo(const std::string &line) const;
+    std::pair<size_t, OrbitalElements> parseLineTwo(const std::string &line1, const std::string &line2) const;
 
 };
 

--- a/src/breakupModel/input/YAMLConfigurationReader.cpp
+++ b/src/breakupModel/input/YAMLConfigurationReader.cpp
@@ -75,6 +75,14 @@ std::optional<std::set<size_t>> YAMLConfigurationReader::getIDFilter() const {
     return std::nullopt;
 }
 
+bool YAMLConfigurationReader::getEnforcedMassConservation() const {
+    if (_file[SIMULATION_TAG][ENFORCE_MASS_CONSERVATION_TAG]) {
+        return _file[SIMULATION_TAG][ENFORCE_MASS_CONSERVATION_TAG].as<bool>();
+    } else {
+        return false;
+    }
+}
+
 std::vector<std::shared_ptr<OutputWriter>> YAMLConfigurationReader::getOutputTargets() const {
     if (_file[RESULT_OUTPUT_TAG]) {
         return extractOutputWriter(_file[RESULT_OUTPUT_TAG]);

--- a/src/breakupModel/input/YAMLConfigurationReader.cpp
+++ b/src/breakupModel/input/YAMLConfigurationReader.cpp
@@ -75,7 +75,7 @@ std::optional<std::set<size_t>> YAMLConfigurationReader::getIDFilter() const {
     return std::nullopt;
 }
 
-bool YAMLConfigurationReader::getEnforcedMassConservation() const {
+bool YAMLConfigurationReader::getEnforceMassConservation() const {
     if (_file[SIMULATION_TAG][ENFORCE_MASS_CONSERVATION_TAG]) {
         return _file[SIMULATION_TAG][ENFORCE_MASS_CONSERVATION_TAG].as<bool>();
     } else {

--- a/src/breakupModel/input/YAMLConfigurationReader.h
+++ b/src/breakupModel/input/YAMLConfigurationReader.h
@@ -26,6 +26,7 @@ class YAMLConfigurationReader : public InputConfigurationSource, public OutputCo
     static constexpr char CURRENT_MAX_ID_TAG[] = "currentMaxID";
     static constexpr char INPUT_SOURCE_TAG[] = "inputSource";
     static constexpr char ID_FILTER_TAG[] = "idFilter";
+    static constexpr char ENFORCE_MASS_CONSERVATION_TAG[] = "enforceMassConservation";
     static constexpr char RESULT_OUTPUT_TAG[] = "resultOutput";
     static constexpr char INPUT_OUTPUT_TAG[] = "inputOutput";
     static constexpr char TARGET_TAG[] = "target";
@@ -95,6 +96,13 @@ public:
      * @return filter or empty
      */
     std::optional<std::set<size_t>> getIDFilter() const override;
+
+    /**
+     * Returns a bool which states if the simulation should enforce the mass conservation through the generation
+     * of additional fragments if the mass budget was not yet exceeded (after the normal run)
+     * @return true or false if a value is given for this TAG in the YAML file, otherwise always false
+     */
+    bool getEnforcedMassConservation() const override;
 
     /**
      * Reads in which Output is wished by the YAML file.

--- a/src/breakupModel/input/YAMLConfigurationReader.h
+++ b/src/breakupModel/input/YAMLConfigurationReader.h
@@ -102,7 +102,7 @@ public:
      * of additional fragments if the mass budget was not yet exceeded (after the normal run)
      * @return true or false if a value is given for this TAG in the YAML file, otherwise always false
      */
-    bool getEnforcedMassConservation() const override;
+    bool getEnforceMassConservation() const override;
 
     /**
      * Reads in which Output is wished by the YAML file.

--- a/src/breakupModel/model/OrbitalElements.cpp
+++ b/src/breakupModel/model/OrbitalElements.cpp
@@ -11,6 +11,7 @@ std::tm Epoch::toTm() const {
 
     //Month and Day
     const int dayInYear = static_cast<int>(fraction);
+    tmInstance.tm_yday = dayInYear;
     int dayInMonth = dayInYear;
     for (const auto&[month, days] : monthToDaysMap) {
         if (dayInMonth <= days) {

--- a/src/breakupModel/model/OrbitalElements.cpp
+++ b/src/breakupModel/model/OrbitalElements.cpp
@@ -1,5 +1,44 @@
 #include "OrbitalElements.h"
 
+bool Epoch::isInvalid() const  {
+    return year < 0 || fraction < 0;
+}
+
+std::tm Epoch::toTm() const {
+    std::tm tmInstance{};
+    //Year
+    tmInstance.tm_year = year;
+
+    //Month and Day
+    const int dayInYear = static_cast<int>(fraction);
+    int dayInMonth = dayInYear;
+    for (const auto&[month, days] : monthToDaysMap) {
+        if (dayInMonth <= days) {
+            tmInstance.tm_mon = month;
+            tmInstance.tm_mday = dayInMonth;
+            break;
+        } else {
+            dayInMonth -= days;
+        }
+    }
+    //Hours
+    double fractionOfDay = fraction - dayInYear;
+    double hours = fractionOfDay * 24;
+    tmInstance.tm_hour = static_cast<int>(hours);
+
+    //Minutes
+    fractionOfDay = hours - tmInstance.tm_hour;
+    double minutes = fractionOfDay * 60;
+    tmInstance.tm_min = static_cast<int>(minutes);
+
+    //Seconds
+    fractionOfDay = minutes - tmInstance.tm_min;
+    double seconds = fractionOfDay * 60;
+    tmInstance.tm_sec = static_cast<int>(seconds);
+
+    return tmInstance;
+}
+
 std::array<double, 6> OrbitalElements::getAsArray() const {
     return std::array<double, 6>{_semiMajorAxis, _eccentricity, _inclination,
                                  _longitudeOfTheAscendingNode, _argumentOfPeriapsis, _eccentricAnomaly};
@@ -46,6 +85,10 @@ double OrbitalElements::getArgumentOfPeriapsis(AngularUnit angularUnit) const {
 
 double OrbitalElements::getAnomaly(AngularUnit angularUnit, OrbitalAnomalyType anomalyType) const {
     return convertEccentricAnomaly(_eccentricAnomaly, _eccentricity, angularUnit, anomalyType);
+}
+
+Epoch OrbitalElements::getEpoch() const {
+    return _epoch;
 }
 
 bool operator==(const OrbitalElements &lhs, const OrbitalElements &rhs) {

--- a/src/breakupModel/model/OrbitalElements.h
+++ b/src/breakupModel/model/OrbitalElements.h
@@ -25,14 +25,50 @@ enum class OrbitalAnomalyType {
  * This enum fulfills the more "readability" purpose.
  */
 enum OrbitalElement {
-    SEMI_MAJOR_AXIS=0,
-    ECCENTRICITY=1,
-    INCLINATION=2,
-    LONGITUDE_OF_THE_ASCENDING_NODE=3,
-    ARGUMENT_OF_PERIAPSIS=4,
-    ECCENTRIC_ANOMALY=5
+    SEMI_MAJOR_AXIS = 0,
+    ECCENTRICITY = 1,
+    INCLINATION = 2,
+    LONGITUDE_OF_THE_ASCENDING_NODE = 3,
+    ARGUMENT_OF_PERIAPSIS = 4,
+    ECCENTRIC_ANOMALY = 5
 };
 
+/**
+ * This struct saves an Epoch for Orbital Elements. It contains of two elements:<br>
+ * - The year (e. g. 2006)<br>
+ * - The day + fraction of a day (e. g. 31.25992506 --> translates to day 31 of the year (would be January) and
+ *   6 hours 14 minutes and 17.52 second)
+ *  Calculation of the hours follows this scheme: floor(0.25992506 * 24) = 6 hours
+ *  The Epoch is invalid if the values inside are negative
+ */
+struct Epoch {
+
+    /**
+     * The year of the Epoch
+     */
+    const int year;
+
+    /**
+     * The day + the fraction of the day
+     */
+    const double fraction;
+
+    Epoch()
+            : year{-1},
+              fraction{-1} {}
+
+    Epoch(int year, double fraction)
+            : year{year},
+              fraction{fraction} {}
+
+    /**
+     * Returns true if this Epoch contains invalid numbers.
+     * @return true if invalid
+     */
+    bool isInvalid() const {
+        return year < 0 || fraction < 0;
+    }
+};
 
 class OrbitalElements {
 

--- a/src/breakupModel/model/OrbitalElementsFactory.cpp
+++ b/src/breakupModel/model/OrbitalElementsFactory.cpp
@@ -1,13 +1,13 @@
 #include "OrbitalElementsFactory.h"
 
-OrbitalElements OrbitalElementsFactory::createFromTLEData(const std::array<double, 6> &tleData) const {
+OrbitalElements OrbitalElementsFactory::createFromTLEData(const std::array<double, 6> &tleData, const Epoch &epoch) const {
     auto degKepler = tleData;
     degKepler[0] = util::meanMotionToSemiMajorAxis(degKepler[0]);
-    return createFromOnlyDegree(degKepler, OrbitalAnomalyType::MEAN);
+    return createFromOnlyDegree(degKepler, OrbitalAnomalyType::MEAN, epoch);
 }
 
 OrbitalElements OrbitalElementsFactory::createFromOnlyRadians(const std::array<double, 6> &standardKepler,
-                                                              OrbitalAnomalyType orbitalAnomalyType) const {
+                                                      OrbitalAnomalyType orbitalAnomalyType, const Epoch &epoch) const {
     double anomaly = standardKepler[5];
     if (orbitalAnomalyType == OrbitalAnomalyType::MEAN) {
         anomaly = util::meanAnomalyToEccentricAnomaly(anomaly, standardKepler[1]);
@@ -16,16 +16,16 @@ OrbitalElements OrbitalElementsFactory::createFromOnlyRadians(const std::array<d
     }   //else ECCENTRIC --> right format
 
     return OrbitalElements(standardKepler[0], standardKepler[1], standardKepler[2],
-                           standardKepler[3], standardKepler[4], anomaly);
+                           standardKepler[3], standardKepler[4], anomaly, epoch);
 }
 
 OrbitalElements OrbitalElementsFactory::createFromOnlyDegree(const std::array<double, 6> &standardKepler,
-                                                             OrbitalAnomalyType orbitalAnomalyType) const {
+                                                 OrbitalAnomalyType orbitalAnomalyType, const Epoch &epoch) const {
     auto radKepler = standardKepler;
     for (unsigned int i = 2; i < 6; ++i) {
         radKepler[i] = util::degToRad(radKepler[i]);
     }
-    return createFromOnlyRadians(radKepler, orbitalAnomalyType);
+    return createFromOnlyRadians(radKepler, orbitalAnomalyType, epoch);
 }
 
 OrbitalElements OrbitalElementsFactory::createOrbitalElements(double a, double eccentricity, double inclination,

--- a/src/breakupModel/model/OrbitalElementsFactory.h
+++ b/src/breakupModel/model/OrbitalElementsFactory.h
@@ -25,8 +25,10 @@ public:
     * W - longitude of the ascending node (big omega) [deg]<br>
     * w - argument of periapsis (small omega) [deg]<br>
     * MA - Mean Anomaly [deg]<br>
+    * @param epoch - the Epoch of these Elements (default empty)
     */
-    [[nodiscard]] OrbitalElements createFromTLEData(const std::array<double, 6> &tleData) const;
+    [[nodiscard]] OrbitalElements createFromTLEData(const std::array<double, 6> &tleData,
+                                                    const Epoch &epoch = Epoch{}) const;
 
     /**
     * Constructs the Orbital Elements from the standard keplerian Elements in the following order:
@@ -38,9 +40,11 @@ public:
     * w - argument of periapsis (small omega) [rad]<br>
     * A - an anomaly in [rad]<br>
     * @param orbitalAnomalyType - this defines the last element in the array, either: ECCENTRIC, MEAN or TRUE
+    * @param epoch - the Epoch of these Elements (default empty)
     */
     [[nodiscard]] OrbitalElements
-    createFromOnlyRadians(const std::array<double, 6> &standardKepler, OrbitalAnomalyType orbitalAnomalyType) const;
+    createFromOnlyRadians(const std::array<double, 6> &standardKepler, OrbitalAnomalyType orbitalAnomalyType,
+                          const Epoch &epoch = Epoch{}) const;
 
     /**
     * Constructs the Orbital Elements from the standard keplerian Elements in the following order:
@@ -52,9 +56,11 @@ public:
     * w - argument of periapsis (small omega) [deg]<br>
     * A - an anomaly in [deg]<br>
     * @param orbitalAnomalyType - this defines the last element in the array, either: ECCENTRIC, MEAN or TRUE
+    * @param epoch - the Epoch of these Elements (default empty)
     */
     [[nodiscard]] OrbitalElements
-    createFromOnlyDegree(const std::array<double, 6> &standardKepler, OrbitalAnomalyType orbitalAnomalyType) const;
+    createFromOnlyDegree(const std::array<double, 6> &standardKepler, OrbitalAnomalyType orbitalAnomalyType,
+                         const Epoch &epoch = Epoch{}) const;
 
     /**
      * Creates the orbital elements from the user's wish units:

--- a/src/breakupModel/model/Satellite.h
+++ b/src/breakupModel/model/Satellite.h
@@ -303,7 +303,7 @@ public:
      * @param velocity - cartesian vector
      */
     void setVelocity(const std::array<double, 3> &velocity) {
-        //Orbital Elements if they where previously calculated are now invalid
+        //Orbital Elements if they were previously calculated are now invalid
         _orbitalElementsCache = std::nullopt;
         _velocity = velocity;
     }
@@ -320,19 +320,6 @@ public:
      */
     void setEjectionVelocity(const std::array<double, 3> &ejectionVelocity) {
         _ejectionVelocity = ejectionVelocity;
-    }
-
-    /**
-     * Sets the ejection velocity of this Satellite (debris-fragment)
-     * and adds in on top of the base velocity.
-     * @note This does modifies the state, but the the ejection velocity is property of the breakup and not directly
-     * linked to the Satellite like it is the "whole" velocity. The _orbitalElementsCache is therefore not invalidated.
-     * @param ejectionVelocity - cartesian vector
-     */
-    void addEjectionVelocity(const std::array<double, 3> &ejectionVelocity) {
-        using util::operator+;
-        _ejectionVelocity = ejectionVelocity;
-        _velocity = _velocity + _ejectionVelocity;
     }
 
     [[nodiscard]] const std::array<double, 3> &getPosition() const {

--- a/src/breakupModel/model/Satellites.cpp
+++ b/src/breakupModel/model/Satellites.cpp
@@ -4,7 +4,7 @@ std::vector<std::tuple<double &, std::array<double, 3> &, std::array<double, 3> 
     std::vector<std::tuple<double &, std::array<double, 3> &, std::array<double, 3> &>> vector{};
     vector.reserve(size());
     for (size_t i = 0; i < size(); ++i) {
-        vector.emplace_back(_areaToMassRatio[i], _velocity[i], _ejectionVelocity[i]);
+        vector.emplace_back(areaToMassRatio[i], velocity[i], ejectionVelocity[i]);
     }
     return vector;
 }
@@ -13,7 +13,7 @@ std::vector<std::tuple<double &, double &, double &, double &>> Satellites::getA
     std::vector<std::tuple<double &, double &, double &, double &>> vector{};
     vector.reserve(size());
     for (size_t i = 0; i < size(); ++i) {
-        vector.emplace_back(_characteristicLength[i], _areaToMassRatio[i], _area[i], _mass[i]);
+        vector.emplace_back(characteristicLength[i], areaToMassRatio[i], area[i], mass[i]);
     }
     return vector;
 }
@@ -23,7 +23,7 @@ Satellites::getCMVNTuple() {
     std::vector<std::tuple<double &, double &, std::array<double, 3> &, std::shared_ptr<const std::string> &>> vector{};
     vector.reserve(size());
     for (size_t i = 0; i < size(); ++i) {
-        vector.emplace_back(_characteristicLength[i], _mass[i], _velocity[i], _name[i]);
+        vector.emplace_back(characteristicLength[i], mass[i], velocity[i], name[i]);
     }
     return vector;
 }
@@ -32,7 +32,7 @@ std::vector<std::tuple<std::array<double, 3> &, std::shared_ptr<const std::strin
     std::vector<std::tuple<std::array<double, 3> &, std::shared_ptr<const std::string> &>> vector{};
     vector.reserve(size());
     for (size_t i = 0; i < size(); ++i) {
-        vector.emplace_back(_velocity[i], _name[i]);
+        vector.emplace_back(velocity[i], name[i]);
     }
     return vector;
 }
@@ -40,19 +40,19 @@ std::vector<std::tuple<std::array<double, 3> &, std::shared_ptr<const std::strin
 std::vector<Satellite> Satellites::getAoS() const {
     std::vector<Satellite> vector{};
     size_t size = this->size();
-    size_t id = _startID;
+    size_t id = startId;
     vector.reserve(size);
 
-    auto nameIt = _name.begin();
-    auto lcIt = _characteristicLength.begin();
-    auto amIt = _areaToMassRatio.begin();
-    auto mIt = _mass.begin();
-    auto aIt = _area.begin();
-    auto vIt = _velocity.begin();
-    auto evIt = _ejectionVelocity.begin();
+    auto nameIt = name.begin();
+    auto lcIt = characteristicLength.begin();
+    auto amIt = areaToMassRatio.begin();
+    auto mIt = mass.begin();
+    auto aIt = area.begin();
+    auto vIt = velocity.begin();
+    auto evIt = ejectionVelocity.begin();
 
-    for (; lcIt != _characteristicLength.end(); ++nameIt, ++lcIt, ++amIt, ++mIt, ++aIt, ++vIt, ++evIt) {
-        vector.emplace_back(id++, *nameIt, _satType, *lcIt, *amIt, *mIt, *aIt, *vIt, *evIt, _position);
+    for (; lcIt != characteristicLength.end(); ++nameIt, ++lcIt, ++amIt, ++mIt, ++aIt, ++vIt, ++evIt) {
+        vector.emplace_back(id++, *nameIt, satType, *lcIt, *amIt, *mIt, *aIt, *vIt, *evIt, position);
     }
     return vector;
 }
@@ -64,6 +64,6 @@ void Satellites::popBack() {
 std::tuple<double &, double &, double &, double &> Satellites::appendElement() {
     this->resize(this->size() + 1);
     return std::tuple<double &, double &, double &, double &>
-            {_characteristicLength.back(), _areaToMassRatio.back(), _area.back(), _mass.back()};
+            {characteristicLength.back(), areaToMassRatio.back(), area.back(), mass.back()};
 }
 

--- a/src/breakupModel/model/Satellites.cpp
+++ b/src/breakupModel/model/Satellites.cpp
@@ -57,3 +57,13 @@ std::vector<Satellite> Satellites::getAoS() const {
     return vector;
 }
 
+void Satellites::popBack() {
+    this->resize(this->size() - 1);
+}
+
+std::tuple<double &, double &, double &, double &> Satellites::appendElement() {
+    this->resize(this->size() + 1);
+    return std::tuple<double &, double &, double &, double &>
+            {_characteristicLength.back(), _areaToMassRatio.back(), _area.back(), _mass.back()};
+}
+

--- a/src/breakupModel/model/Satellites.h
+++ b/src/breakupModel/model/Satellites.h
@@ -25,18 +25,18 @@ struct Satellites {
      * The NORAD Catalog ID of the first Satellite in the SoA
      * That means this contains Satellites from [StartID, StartID+size]
      */
-    size_t _startID{};
+    size_t startId{};
 
     /**
      * The SatType of the Satellites in the SoA
      */
-    SatType _satType{SatType::DEBRIS};
+    SatType satType{SatType::DEBRIS};
 
     /**
      * The position base of the Satellites in the SoA
      * This is a cartesian position vector in [m]
      */
-    std::array<double, 3> _position{};
+    std::array<double, 3> position{};
 
     /*
      * Unique Properties
@@ -45,46 +45,46 @@ struct Satellites {
     /**
      * The name of each of the Satellites in the SoA
      */
-    std::vector<std::shared_ptr<const std::string>> _name;
+    std::vector<std::shared_ptr<const std::string>> name;
 
     /**
      * The characteristic length of each satellite in [m]
      */
-    std::vector<double> _characteristicLength;
+    std::vector<double> characteristicLength;
 
     /**
      * The area-to-mass ratio of each satellite in [m^2/kg]
      */
-    std::vector<double> _areaToMassRatio;
+    std::vector<double> areaToMassRatio;
 
     /**
      * The mass of each satellite in [kg]
      */
-    std::vector<double> _mass;
+    std::vector<double> mass;
 
     /**
      * The area/ Radar-Cross-Section of each satellite in [m^2]
      */
-    std::vector<double> _area;
+    std::vector<double> area;
 
     /**
      * The ejection velocity of each satellite in [m/s]
      * This is a cartesian velocity vector.
      */
-    std::vector<std::array<double, 3>> _ejectionVelocity;
+    std::vector<std::array<double, 3>> ejectionVelocity;
 
     /**
      * The velocity of each satellite in [m/s]
      * This is a cartesian velocity vector in which each element is the sum of ejection and (parental) base velocity
      */
-    std::vector<std::array<double, 3>> _velocity;
+    std::vector<std::array<double, 3>> velocity;
 
     Satellites() = default;
 
     Satellites(size_t startID, SatType satType, std::array<double, 3> position, size_t size)
-            : _startID{startID},
-              _satType{satType},
-              _position{position} {
+            : startId{startID},
+              satType{satType},
+              position{position} {
         this->resize(size);
     }
 
@@ -127,7 +127,7 @@ struct Satellites {
      * @return size
      */
     size_t size() const {
-        return _characteristicLength.size();
+        return characteristicLength.size();
     }
 
     /**
@@ -135,13 +135,13 @@ struct Satellites {
      * @param newSize
      */
     void resize(size_t newSize) {
-        _name.resize(newSize);
-        _characteristicLength.resize(newSize);
-        _areaToMassRatio.resize(newSize);
-        _mass.resize(newSize);
-        _area.resize(newSize);
-        _ejectionVelocity.resize(newSize);
-        _velocity.resize(newSize);
+        name.resize(newSize);
+        characteristicLength.resize(newSize);
+        areaToMassRatio.resize(newSize);
+        mass.resize(newSize);
+        area.resize(newSize);
+        ejectionVelocity.resize(newSize);
+        velocity.resize(newSize);
     }
 
     /**

--- a/src/breakupModel/model/Satellites.h
+++ b/src/breakupModel/model/Satellites.h
@@ -13,7 +13,7 @@
  * This class implements the Satellites in an SoA (Structure of Array) way.
  * This is especially useful for the BreakupSimulation to vectorized calculation and save memory for shared
  * properties of the fragment satellites created.
- * @note This class provides a method to transform the SoA structure into an AoS approach (std::vector<Satellite>)
+ * @note This class provides a method to copy the SoA structure into an AoS approach (std::vector<Satellite>)
  */
 class Satellites {
 

--- a/src/breakupModel/model/Satellites.h
+++ b/src/breakupModel/model/Satellites.h
@@ -144,4 +144,17 @@ struct Satellites {
         _velocity.resize(newSize);
     }
 
+    /**
+     * Removes the last element from this Satellites Structure.
+     * This resizes the interior vectors to a size one smaller than before the method call.
+     */
+    void popBack();
+
+    /**
+     * This resizes the Structure by one additional Slot and returns references to the
+     * characteristic length, area-mass-ratio, area and mass of the new element.
+     * @return tuple of references to characteristic length, area-mass-ratio, area and mass
+     */
+    std::tuple<double &, double &, double &, double &> appendElement();
+
 };

--- a/src/breakupModel/model/Satellites.h
+++ b/src/breakupModel/model/Satellites.h
@@ -15,7 +15,9 @@
  * properties of the fragment satellites created.
  * @note This class provides a method to transform the SoA structure into an AoS approach (std::vector<Satellite>)
  */
-struct Satellites {
+class Satellites {
+
+public:
 
     /*
      * Shared Properties

--- a/src/breakupModel/output/CSVPatternWriter.cpp
+++ b/src/breakupModel/output/CSVPatternWriter.cpp
@@ -13,6 +13,10 @@ const std::map<char, std::function<void(const Satellite &sat,
             using util::operator<<;
             stream << sat.getVelocity();
         }},
+        {'j', [](const Satellite &sat, std::stringstream &stream) -> void {
+            using util::operator<<;
+            stream << sat.getEjectionVelocity();
+        }},
         {'p', [](const Satellite &sat, std::stringstream &stream) -> void {
             using util::operator<<;
             stream << sat.getPosition();
@@ -52,6 +56,7 @@ const std::map<char, std::string> CSVPatternWriter::headerMap{
         {'A', "Area [m^2]"},
         {'m', "Mass [kg]"},
         {'v', "Velocity [m/s]"},
+        {'j', "Ejection Velocity [m/s]"},
         {'p', "Position [m]"},
         {'a', "Semi-Major-Axis [m]"},
         {'e', "Eccentricity"},
@@ -75,6 +80,7 @@ void CSVPatternWriter::printResult(const std::vector<Satellite> &satelliteCollec
     //CSV Lines
     for (const auto &sat : satelliteCollection) {
         std::stringstream stream{};
+        stream.precision(17);
         for (auto funIt = _myToDo.begin(); funIt != _myToDo.end() - 1; ++funIt) {
             (*funIt)(sat, stream);
             stream << ',';

--- a/src/breakupModel/output/VTKWriter.cpp
+++ b/src/breakupModel/output/VTKWriter.cpp
@@ -10,6 +10,7 @@ void VTKWriter::printResult(const std::vector<Satellite> &satelliteCollection) c
     this->printProperty<double, Satellite>("area", &Satellite::getArea, satelliteCollection);
     this->printProperty<double, Satellite>("area-to-mass", &Satellite::getAreaToMassRatio, satelliteCollection);
     this->printProperty<std::array<double, 3>, Satellite>("velocity", &Satellite::getVelocity, satelliteCollection);
+    this->printProperty<std::array<double, 3>, Satellite>("ejection-velocity", &Satellite::getEjectionVelocity, satelliteCollection);
 
     //Separator between point and point-tore-cell data
     this->printSeparator();

--- a/src/breakupModel/simulation/Breakup.cpp
+++ b/src/breakupModel/simulation/Breakup.cpp
@@ -77,10 +77,23 @@ void Breakup::enforceMassConservation() {
         _output.resize(newSize);
     } else if (_enforceMassConservation) {
         //This is written in an else if, because if the former condition was true, we already had too many fragments
-        //So we only need to check this here when no fragments had to be removed.
+        //But we only need to check this here when no fragments had to be removed.
         while (_outputMass < _inputMass) {
-            //TODO
+            //Order in the tuple: 0: L_c | 1: A/M | 2: Area | 3: Mass
+
+            //Create new element and assign values
+            auto tuple = _output.appendElement();
+            std::get<0>(tuple) = calculateCharacteristicLength();
+            std::get<1>(tuple) = calculateAreaMassRatio(std::get<0>(tuple));
+            std::get<2>(tuple) = calculateArea(std::get<0>(tuple));
+            std::get<3>(tuple) = calculateMass(std::get<2>(tuple), std::get<1>(tuple));
+
+            //Calculate new mass
+            _outputMass += std::get<3>(tuple);
         }
+        //Remove the element which has lead to the exceeding of the mass budget
+        _outputMass -= _output._mass.back();
+        _output.popBack();
     }
 }
 

--- a/src/breakupModel/simulation/Breakup.cpp
+++ b/src/breakupModel/simulation/Breakup.cpp
@@ -35,9 +35,11 @@ Breakup &Breakup::setSeed(std::optional<unsigned long> seed) {
     return *this;
 }
 
-void Breakup::generateFragments(size_t fragmentCount, const std::array<double, 3> &position) {
-    //Just in case of a rerun - reset the outputMass to zero
+void Breakup::init() {
     _outputMass = 0;
+}
+
+void Breakup::generateFragments(size_t fragmentCount, const std::array<double, 3> &position) {
     _output = Satellites{_currentMaxGivenID+1, SatType::DEBRIS, position, fragmentCount};
 }
 
@@ -119,7 +121,7 @@ void Breakup::deltaVelocityDistribution() {
         const double mu = _deltaVelocityFactorOffset.first * chi + _deltaVelocityFactorOffset.second;
         constexpr double sigma = 0.4;
         std::normal_distribution<> normalDistribution{mu, sigma};
-        double velocityScalar = std::pow(10, getRandomNumber(normalDistribution));
+        double velocityScalar = std::pow(10.0, getRandomNumber(normalDistribution));
 
         //Transform the scalar velocity into a cartesian vector
         ejectionVelocity = calculateVelocityVector(velocityScalar);
@@ -138,31 +140,30 @@ double Breakup::calculateAreaMassRatio(double characteristicLength) {
     using namespace util;
     const double logLc = std::log10(characteristicLength);
 
-    double areaToMassRatio{0};
-
-    if (characteristicLength > 0.11) {          //Case bigger than 11 cm
+    if (characteristicLength > 0.11) {
+        //Case bigger than 11 cm
         std::normal_distribution<> n1{mu_1(_satType, logLc), sigma_1(_satType, logLc)};
         std::normal_distribution<> n2{mu_2(_satType, logLc), sigma_2(_satType, logLc)};
 
-        areaToMassRatio = std::pow(10, alpha(_satType, logLc) * getRandomNumber(n1) +
-        (1 - alpha(_satType, logLc)) * getRandomNumber(n2));
-    } else if (characteristicLength < 0.08) {   //Case smaller than 8 cm
+        return std::pow(10.0, alpha(_satType, logLc) * getRandomNumber(n1) +
+            (1 - alpha(_satType, logLc)) * getRandomNumber(n2));
+    } else if (characteristicLength < 0.08) {
+        //Case smaller than 8 cm
         std::normal_distribution<> n{mu_soc(logLc), sigma_soc(logLc)};
 
-        areaToMassRatio = std::pow(10, getRandomNumber(n));
-    } else {                                    //Case between 8 cm and 11 cm
+        return std::pow(10.0, getRandomNumber(n));
+    } else {
+        //Case between 8 cm and 11 cm
         std::normal_distribution<> n1{mu_1(_satType, logLc), sigma_1(_satType, logLc)};
         std::normal_distribution<> n2{mu_2(_satType, logLc), sigma_2(_satType, logLc)};
         std::normal_distribution<> n{mu_soc(logLc), sigma_soc(logLc)};
 
-        double y1 = std::pow(10, alpha(_satType, logLc) * getRandomNumber(n1) +
-                                 (1 - alpha(_satType, logLc)) * getRandomNumber(n2));
-        double y0 = std::pow(10, getRandomNumber(n));
+        double y1 = std::pow(10.0, alpha(_satType, logLc) * getRandomNumber(n1) +
+                                 (1.0 - alpha(_satType, logLc)) * getRandomNumber(n2));
+        double y0 = std::pow(10.0, getRandomNumber(n));
 
-        areaToMassRatio = y0 + (characteristicLength - 0.08) * (y1 - y0) / (0.03);
+        return y0 + (characteristicLength - 0.08) * (y1 - y0) / (0.03);
     }
-
-    return areaToMassRatio;
 }
 
 double Breakup::calculateArea(double characteristicLength) {

--- a/src/breakupModel/simulation/Breakup.cpp
+++ b/src/breakupModel/simulation/Breakup.cpp
@@ -75,6 +75,12 @@ void Breakup::enforceMassConservation() {
         spdlog::warn("The simulation reduced the number of fragments because the mass budget was exceeded. "
                      "In other words: The random behaviour has produced heavier fragments");
         _output.resize(newSize);
+    } else if (_enforceMassConservation) {
+        //This is written in an else if, because if the former condition was true, we already had too many fragments
+        //So we only need to check this here when no fragments had to be removed.
+        while (_outputMass < _inputMass) {
+            //TODO
+        }
     }
 }
 

--- a/src/breakupModel/simulation/Breakup.cpp
+++ b/src/breakupModel/simulation/Breakup.cpp
@@ -64,6 +64,8 @@ void Breakup::areaToMassRatioDistribution() {
 void Breakup::enforceMassConservation() {
     //Enforce Mass Conservation if the output mass is greater than the input mass
     _outputMass = std::accumulate(_output._mass.begin(), _output._mass.end(), 0.0);
+    spdlog::debug("The simulation got {} kg of input mass", _inputMass);
+    spdlog::debug("The simulation produced {} kg of debris", _outputMass);
     size_t oldSize = _output.size();
     size_t newSize = _output.size();
     while (_outputMass > _inputMass) {
@@ -74,6 +76,7 @@ void Breakup::enforceMassConservation() {
     if (oldSize != newSize) {
         spdlog::warn("The simulation reduced the number of fragments because the mass budget was exceeded. "
                      "In other words: The random behaviour has produced heavier fragments");
+        spdlog::debug("The simulation corrected to {} kg of debris", _outputMass);
         _output.resize(newSize);
     } else if (_enforceMassConservation) {
         //This is written in an else if, because if the former condition was true, we already had too many fragments
@@ -95,6 +98,7 @@ void Breakup::enforceMassConservation() {
         _outputMass -= _output._mass.back();
         _output.popBack();
         spdlog::warn("The simulation increased the number of fragments to enforce the mass conservation.");
+        spdlog::debug("The simulation corrected to {} kg of debris", _outputMass);
     }
 }
 

--- a/src/breakupModel/simulation/Breakup.cpp
+++ b/src/breakupModel/simulation/Breakup.cpp
@@ -36,6 +36,7 @@ Breakup &Breakup::setSeed(std::optional<unsigned long> seed) {
 }
 
 void Breakup::init() {
+    _inputMass = 0;
     _outputMass = 0;
 }
 

--- a/src/breakupModel/simulation/Breakup.cpp
+++ b/src/breakupModel/simulation/Breakup.cpp
@@ -42,7 +42,7 @@ void Breakup::generateFragments(size_t fragmentCount, const std::array<double, 3
 }
 
 void Breakup::characteristicLengthDistribution() {
-    std::for_each(std::execution::par_unseq, _output._characteristicLength.begin(), _output._characteristicLength.end(),
+    std::for_each(std::execution::par_unseq, _output.characteristicLength.begin(), _output.characteristicLength.end(),
                   [&](double &lc) {
         lc = calculateCharacteristicLength();
     });
@@ -64,15 +64,15 @@ void Breakup::areaToMassRatioDistribution() {
 
 void Breakup::enforceMassConservation() {
     //Enforce Mass Conservation if the output mass is greater than the input mass
-    _outputMass = std::accumulate(_output._mass.begin(), _output._mass.end(), 0.0);
+    _outputMass = std::accumulate(_output.mass.begin(), _output.mass.end(), 0.0);
     spdlog::debug("The simulation got {} kg of input mass", _inputMass);
     spdlog::debug("The simulation produced {} kg of debris", _outputMass);
     size_t oldSize = _output.size();
     size_t newSize = _output.size();
     while (_outputMass > _inputMass) {
-        _outputMass -= _output._mass.back();
+        _outputMass -= _output.mass.back();
         newSize -= 1;
-        _output._mass.pop_back();
+        _output.mass.pop_back();
     }
     if (oldSize != newSize) {
         spdlog::warn("The simulation reduced the number of fragments because the mass budget was exceeded. "
@@ -96,7 +96,7 @@ void Breakup::enforceMassConservation() {
             _outputMass += std::get<3>(tuple);
         }
         //Remove the element which has lead to the exceeding of the mass budget
-        _outputMass -= _output._mass.back();
+        _outputMass -= _output.mass.back();
         _output.popBack();
         spdlog::warn("The simulation increased the number of fragments to enforce the mass conservation.");
         spdlog::debug("The simulation corrected to {} kg of debris", _outputMass);

--- a/src/breakupModel/simulation/Breakup.cpp
+++ b/src/breakupModel/simulation/Breakup.cpp
@@ -65,7 +65,7 @@ void Breakup::areaToMassRatioDistribution() {
 
 void Breakup::enforceMassConservation() {
     //Enforce Mass Conservation if the output mass is greater than the input mass
-    _outputMass = std::accumulate(_output.mass.begin(), _output.mass.end(), 0.0);
+    _outputMass = std::reduce(std::execution::par_unseq,_output.mass.begin(), _output.mass.end(), 0.0);
     spdlog::debug("The simulation got {} kg of input mass", _inputMass);
     spdlog::debug("The simulation produced {} kg of debris", _outputMass);
     size_t oldSize = _output.size();

--- a/src/breakupModel/simulation/Breakup.cpp
+++ b/src/breakupModel/simulation/Breakup.cpp
@@ -163,10 +163,14 @@ double Breakup::calculateAreaMassRatio(double characteristicLength) {
 }
 
 double Breakup::calculateArea(double characteristicLength) {
-    if (characteristicLength < 0.00167) {
-        return 0.540424 * characteristicLength * characteristicLength;
+    constexpr double lcBound = 0.00167;
+    if (characteristicLength < lcBound) {
+        constexpr double factorLittle = 0.540424;
+        return factorLittle * characteristicLength * characteristicLength;
     } else {
-        return 0.556945 * std::pow(characteristicLength, 2.0047077);
+        constexpr double exponentBig = 2.0047077;
+        constexpr double factorBig = 0.556945;
+        return factorBig * std::pow(characteristicLength, exponentBig);
     }
 }
 

--- a/src/breakupModel/simulation/Breakup.cpp
+++ b/src/breakupModel/simulation/Breakup.cpp
@@ -118,7 +118,7 @@ void Breakup::deltaVelocityDistribution() {
         const double chi = log10(areaToMassRatio);
         const double mu = _deltaVelocityFactorOffset.first * chi + _deltaVelocityFactorOffset.second;
         constexpr double sigma = 0.4;
-        std::normal_distribution normalDistribution{mu, sigma};
+        std::normal_distribution<> normalDistribution{mu, sigma};
         double velocityScalar = std::pow(10, getRandomNumber(normalDistribution));
 
         //Transform the scalar velocity into a cartesian vector
@@ -141,19 +141,19 @@ double Breakup::calculateAreaMassRatio(double characteristicLength) {
     double areaToMassRatio{0};
 
     if (characteristicLength > 0.11) {          //Case bigger than 11 cm
-        std::normal_distribution n1{mu_1(_satType, logLc), sigma_1(_satType, logLc)};
-        std::normal_distribution n2{mu_2(_satType, logLc), sigma_2(_satType, logLc)};
+        std::normal_distribution<> n1{mu_1(_satType, logLc), sigma_1(_satType, logLc)};
+        std::normal_distribution<> n2{mu_2(_satType, logLc), sigma_2(_satType, logLc)};
 
         areaToMassRatio = std::pow(10, alpha(_satType, logLc) * getRandomNumber(n1) +
         (1 - alpha(_satType, logLc)) * getRandomNumber(n2));
     } else if (characteristicLength < 0.08) {   //Case smaller than 8 cm
-        std::normal_distribution n{mu_soc(logLc), sigma_soc(logLc)};
+        std::normal_distribution<> n{mu_soc(logLc), sigma_soc(logLc)};
 
         areaToMassRatio = std::pow(10, getRandomNumber(n));
     } else {                                    //Case between 8 cm and 11 cm
-        std::normal_distribution n1{mu_1(_satType, logLc), sigma_1(_satType, logLc)};
-        std::normal_distribution n2{mu_2(_satType, logLc), sigma_2(_satType, logLc)};
-        std::normal_distribution n{mu_soc(logLc), sigma_soc(logLc)};
+        std::normal_distribution<> n1{mu_1(_satType, logLc), sigma_1(_satType, logLc)};
+        std::normal_distribution<> n2{mu_2(_satType, logLc), sigma_2(_satType, logLc)};
+        std::normal_distribution<> n{mu_soc(logLc), sigma_soc(logLc)};
 
         double y1 = std::pow(10, alpha(_satType, logLc) * getRandomNumber(n1) +
                                  (1 - alpha(_satType, logLc)) * getRandomNumber(n2));

--- a/src/breakupModel/simulation/Breakup.cpp
+++ b/src/breakupModel/simulation/Breakup.cpp
@@ -13,6 +13,8 @@ void Breakup::run() {
     //3. Step: Calculate the A/M (area-to-mass-ratio), A (area) and M (mass) values for every Satellite
     this->areaToMassRatioDistribution();
 
+    this->enforceMassConservation();
+
     //4. Step: Assign parent and by doing that assign each fragment a base velocity
     this->assignParentProperties();
 
@@ -57,6 +59,9 @@ void Breakup::areaToMassRatioDistribution() {
         //Calculate the mass m in [kg]
         std::get<3>(tuple) = calculateMass(std::get<2>(tuple), std::get<1>(tuple));
     });
+}
+
+void Breakup::enforceMassConservation() {
     //Enforce Mass Conservation if the output mass is greater than the input mass
     _outputMass = std::accumulate(_output._mass.begin(), _output._mass.end(), 0.0);
     size_t oldSize = _output.size();

--- a/src/breakupModel/simulation/Breakup.cpp
+++ b/src/breakupModel/simulation/Breakup.cpp
@@ -94,6 +94,7 @@ void Breakup::enforceMassConservation() {
         //Remove the element which has lead to the exceeding of the mass budget
         _outputMass -= _output._mass.back();
         _output.popBack();
+        spdlog::warn("The simulation increased the number of fragments to enforce the mass conservation.");
     }
 }
 

--- a/src/breakupModel/simulation/Breakup.cpp
+++ b/src/breakupModel/simulation/Breakup.cpp
@@ -78,6 +78,7 @@ void Breakup::enforceMassConservation() {
     if (oldSize != newSize) {
         spdlog::warn("The simulation reduced the number of fragments because the mass budget was exceeded. "
                      "In other words: The random behaviour has produced heavier fragments");
+        spdlog::warn("The fragment count was reduced from {} to {} fragments.", oldSize, newSize);
         spdlog::debug("The simulation corrected to {} kg of debris", _outputMass);
         _output.resize(newSize);
     } else if (_enforceMassConservation) {
@@ -99,7 +100,9 @@ void Breakup::enforceMassConservation() {
         //Remove the element which has lead to the exceeding of the mass budget
         _outputMass -= _output.mass.back();
         _output.popBack();
+        newSize = _output.size();
         spdlog::warn("The simulation increased the number of fragments to enforce the mass conservation.");
+        spdlog::warn("The fragment count was increased from {} to {} fragments.", oldSize, newSize);
         spdlog::debug("The simulation corrected to {} kg of debris", _outputMass);
     }
 }

--- a/src/breakupModel/simulation/Breakup.cpp
+++ b/src/breakupModel/simulation/Breakup.cpp
@@ -13,15 +13,16 @@ void Breakup::run() {
     //3. Step: Calculate the A/M (area-to-mass-ratio), A (area) and M (mass) values for every Satellite
     this->areaToMassRatioDistribution();
 
+    //4. Step: Enforce the Mass Conservation and remove (or add) fragments
     this->enforceMassConservation();
 
-    //4. Step: Assign parent and by doing that assign each fragment a base velocity
+    //5. Step: Assign parent and by doing that assign each fragment a base velocity
     this->assignParentProperties();
 
-    //5. Step: Calculate the Ejection velocity for every Satellite
+    //6. Step: Calculate the Ejection velocity for every Satellite
     this->deltaVelocityDistribution();
 
-    //6. Step: As a last step set the _currentMaxGivenID to the new valid value
+    //7. Step: As a last step set the _currentMaxGivenID to the new valid value
     _currentMaxGivenID += _output.size();
 }
 

--- a/src/breakupModel/simulation/Breakup.h
+++ b/src/breakupModel/simulation/Breakup.h
@@ -6,6 +6,7 @@
 #include <cmath>
 #include <random>
 #include <algorithm>
+#include <numeric>
 #include <memory>
 #include <execution>
 #include <optional>

--- a/src/breakupModel/simulation/Breakup.h
+++ b/src/breakupModel/simulation/Breakup.h
@@ -181,7 +181,7 @@ protected:
      * This method does set up the process and correctly inits the required variables.
      * Implementation depends on the subclass.
      */
-    virtual void init() = 0;
+    virtual void init();
 
     /**
      * Creates the a number of fragments, following the Equation 2 for Explosions and

--- a/src/breakupModel/simulation/Breakup.h
+++ b/src/breakupModel/simulation/Breakup.h
@@ -238,6 +238,7 @@ private:
 
     /**
      * This Method calculates one characteristic Length for one Debris Particle.
+     * This method uses equation (2) and (4) from the the NASA Breakup Model Paper.
      * @return L_c in [m]
      */
     double calculateCharacteristicLength();
@@ -245,6 +246,7 @@ private:
     /**
      * Calculates an A/M Value for a given L_c.
      * The utilised equation is chosen based on L_c and the SatType attribute of this Breakup.
+     * This method uses equation (5), (6) and (7) from the the NASA Breakup Model Paper.
      * @param characteristicLength in [m]
      * @return A/M value in [m^2/kg]
      */
@@ -252,6 +254,7 @@ private:
 
     /**
      * Calculates the Area for one fragment.
+     * This method uses equation (8) and (9) from the the NASA Breakup Model Paper.
      * @param characteristicLength in [m]
      * @return Area in [m^2]
      */
@@ -259,6 +262,7 @@ private:
 
     /**
      * Calculates the Mass for one fragment.
+     * This method uses equation (10) from the the NASA Breakup Model Paper.
      * @param area in [m^2]
      * @param areaMassRatio in [m^2/kg]
      * @return Mass in [kg]

--- a/src/breakupModel/simulation/Breakup.h
+++ b/src/breakupModel/simulation/Breakup.h
@@ -124,10 +124,12 @@ public:
             : _input{std::move(input)},
               _minimalCharacteristicLength{minimalCharacteristicLength} {};
 
-    Breakup(std::vector<Satellite> input, double minimalCharacteristicLength, size_t currentMaxGivenID)
+    Breakup(std::vector<Satellite> input, double minimalCharacteristicLength,
+            size_t currentMaxGivenID, bool enforceMassConservation)
             : _input{std::move(input)},
               _minimalCharacteristicLength{minimalCharacteristicLength},
-              _currentMaxGivenID{currentMaxGivenID} {}
+              _currentMaxGivenID{currentMaxGivenID},
+              _enforceMassConservation{enforceMassConservation} {}
 
 
     virtual ~Breakup() = default;

--- a/src/breakupModel/simulation/Breakup.h
+++ b/src/breakupModel/simulation/Breakup.h
@@ -230,9 +230,9 @@ private:
      */
     double calculateAreaMassRatio(double characteristicLength);
 
-    double calculateArea(double characteristicLength);
+    static double calculateArea(double characteristicLength);
 
-    double calculateMass(double area, double areaMassRatio);
+    static double calculateMass(double area, double areaMassRatio);
 
     /**
      * Transforms a scalar velocity into a 3-dimensional cartesian velocity vector.

--- a/src/breakupModel/simulation/Breakup.h
+++ b/src/breakupModel/simulation/Breakup.h
@@ -69,6 +69,13 @@ protected:
     double _outputMass{0};
 
     /**
+     * This is per default false.
+     * If this is set top true then the method enforceMassConservation() will add additional fragments to the
+     * output until the output mass approximately equals the input mass.
+     */
+    bool _enforceMassConservation{false};
+
+    /**
      * Contains the Power Law Exponent for the L_c distribution.
      * This constant is correctly set-up in the subclasses by an init method.
      */

--- a/src/breakupModel/simulation/Breakup.h
+++ b/src/breakupModel/simulation/Breakup.h
@@ -210,6 +210,11 @@ protected:
      */
     void areaToMassRatioDistribution();
 
+    /**
+     * This method enforces the Mass Conservation.
+     * It removes fragments if outputMass > inputMass and
+     * it generates more fragments if outputMass < inputMass && _enforceMassConservation is enabled
+     */
     void enforceMassConservation();
 
     /**
@@ -231,18 +236,33 @@ protected:
 
 private:
 
+    /**
+     * This Method calculates one characteristic Length for one Debris Particle.
+     * @return L_c in [m]
+     */
     double calculateCharacteristicLength();
 
     /**
      * Calculates an A/M Value for a given L_c.
      * The utilised equation is chosen based on L_c and the SatType attribute of this Breakup.
      * @param characteristicLength in [m]
-     * @return A/M value
+     * @return A/M value in [m^2/kg]
      */
     double calculateAreaMassRatio(double characteristicLength);
 
+    /**
+     * Calculates the Area for one fragment.
+     * @param characteristicLength in [m]
+     * @return Area in [m^2]
+     */
     static double calculateArea(double characteristicLength);
 
+    /**
+     * Calculates the Mass for one fragment.
+     * @param area in [m^2]
+     * @param areaMassRatio in [m^2/kg]
+     * @return Mass in [kg]
+     */
     static double calculateMass(double area, double areaMassRatio);
 
 

--- a/src/breakupModel/simulation/Breakup.h
+++ b/src/breakupModel/simulation/Breakup.h
@@ -69,6 +69,18 @@ protected:
     double _outputMass{0};
 
     /**
+     * Contains the Power Law Exponent for the L_c distribution.
+     * This constant is correctly set-up in the subclasses by an init method.
+     */
+    double _lcPowerLawExponent{0};
+
+    /**
+     * Contains Factor and Offset of the Delta (Ejection) Velocity Distribution.
+     * This constant is correctly set-up in the subclasses by an init method.
+     */
+    std::pair<double, double> _deltaVelocityFactorOffset{std::make_pair(0, 0)};
+
+    /**
      * This is potential member for testing purpose. It allows the user to fixate a specific seed (with the
      * method setSeed()). The produced std::mt19937 is then saved in this member and used to calculate random
      * values. The access on this member must be thread safe!
@@ -156,6 +168,12 @@ public:
 protected:
 
     /**
+     * This method does set up the process and correctly inits the required variables.
+     * Implementation depends on the subclass.
+     */
+    virtual void init() = 0;
+
+    /**
      * Creates the a number of fragments, following the Equation 2 for Explosions and
      * Equation 4 for Collisions.
      */
@@ -168,24 +186,14 @@ protected:
      * @param debrisName - the name for the fragments
      * @param position - position of the fragment, derived from the one parent (explosion) or from first parent (collision)
      */
-    virtual void
-    generateFragments(size_t fragmentCount, const std::array<double, 3> &position);
-
-    /**
-     * Creates the Size Distribution. After the fragments are generated this method will assign
-     * every fragment a L_c value based on the corresponding power law distribution (Equation 2 and 4).
-     * Contains the specific part, so this method is for each subclass different.
-     * @note This method is implemented in the subclasses and calls the general form with parameters in the base class
-     */
-    virtual void characteristicLengthDistribution() = 0;
+    virtual void generateFragments(size_t fragmentCount, const std::array<double, 3> &position);
 
     /**
      * Creates the Size Distribution according to an specific powerLaw Exponent.
-     * The Exponent comes from the probability density function (pdf).
-     * @attention Implemented in the base class, called by the subclasses with their parameters
-     * @param powerLawExponent - double
+     * The Exponent comes from the probability density function (pdf) and depends on the subclass.
+     * The subclasses therefore init _lcPowerLawExponent differently.
      */
-    virtual void characteristicLengthDistribution(double powerLawExponent);
+    virtual void characteristicLengthDistribution();
 
     /**
      * Creates for every satellite the area-to-mass ratio according to Equation 6.
@@ -202,23 +210,13 @@ protected:
     virtual void assignParentProperties() = 0;
 
     /**
-     * Implements the Delta Velocity Distribution (ejection velocity).
-     * Assigns every satellite an cartesian velocity vector.
-     * Therefore it first calculates the velocity according to Equation 11/ 12 as an scalar and transform this
-     * into an cartesian vector.
-     * @note This method is implemented in the subclasses and calls the general form with parameters in the base class
-     */
-    virtual void deltaVelocityDistribution() = 0;
-
-    /**
      * Implements the Delta Velocity Distribution according to Equation 11/ 12.
      * The parameters can be described as the following: mu = factor * chi + offset where mu is the mean value of the
-     * normal distribution.
-     * @attention Implemented in the base class, called by the subclasses with their parameters
-     * @param factor - for the chi
-     * @param offset - on top of the chi
+     * normal distribution. The factor and the offset are both saved,
+     * depending on the subclass with different values, in _deltaVelocityFactorOffset
+     * The subclasses therefore init _deltaVelocityFactorOffset differently.
      */
-    virtual void deltaVelocityDistribution(double factor, double offset);
+    virtual void deltaVelocityDistribution();
 
 private:
 

--- a/src/breakupModel/simulation/Breakup.h
+++ b/src/breakupModel/simulation/Breakup.h
@@ -220,13 +220,19 @@ protected:
 
 private:
 
+    double calculateCharacteristicLength();
+
     /**
      * Calculates an A/M Value for a given L_c.
      * The utilised equation is chosen based on L_c and the SatType attribute of this Breakup.
      * @param characteristicLength in [m]
      * @return A/M value
      */
-    double calculateAM(double characteristicLength);
+    double calculateAreaMassRatio(double characteristicLength);
+
+    double calculateArea(double characteristicLength);
+
+    double calculateMass(double area, double areaMassRatio);
 
     /**
      * Transforms a scalar velocity into a 3-dimensional cartesian velocity vector.

--- a/src/breakupModel/simulation/Breakup.h
+++ b/src/breakupModel/simulation/Breakup.h
@@ -193,13 +193,15 @@ protected:
      * The Exponent comes from the probability density function (pdf) and depends on the subclass.
      * The subclasses therefore init _lcPowerLawExponent differently.
      */
-    virtual void characteristicLengthDistribution();
+    void characteristicLengthDistribution();
 
     /**
      * Creates for every satellite the area-to-mass ratio according to Equation 6.
      * This method also ensures that the output mass does not exceed the input mass.
      */
-    virtual void areaToMassRatioDistribution();
+    void areaToMassRatioDistribution();
+
+    void enforceMassConservation();
 
     /**
      * This Method does assign each fragment a parent (trivial in Explosion case) and checks that
@@ -216,7 +218,7 @@ protected:
      * depending on the subclass with different values, in _deltaVelocityFactorOffset
      * The subclasses therefore init _deltaVelocityFactorOffset differently.
      */
-    virtual void deltaVelocityDistribution();
+    void deltaVelocityDistribution();
 
 private:
 
@@ -234,6 +236,7 @@ private:
 
     static double calculateMass(double area, double areaMassRatio);
 
+
     /**
      * Transforms a scalar velocity into a 3-dimensional cartesian velocity vector.
      * The transformation is based around a uniform Distribution.
@@ -241,7 +244,6 @@ private:
      * @return 3-dimensional cartesian velocity vector
      */
     std::array<double, 3> calculateVelocityVector(double velocity);
-
 
     /**
      * Returns a random number according to a specific distribution.
@@ -275,7 +277,6 @@ public:
     [[nodiscard]] size_t getCurrentMaxGivenId() const {
         return _currentMaxGivenID;
     }
-
 };
 
 

--- a/src/breakupModel/simulation/BreakupBuilder.cpp
+++ b/src/breakupModel/simulation/BreakupBuilder.cpp
@@ -6,6 +6,7 @@ BreakupBuilder &BreakupBuilder::reconfigure(const std::shared_ptr<InputConfigura
     this->setSimulationType(configurationSource->getTypeOfSimulation());
     this->setCurrentMaximalGivenID(configurationSource->getCurrentMaximalGivenID()),
     this->setIDFilter(configurationSource->getIDFilter());
+    this->setEnforceMassConservation(configurationSource->getEnforceMassConservation());
     this->setDataSource(configurationSource->getDataReader());
     return *this;
 }
@@ -32,6 +33,11 @@ BreakupBuilder &BreakupBuilder::setCurrentMaximalGivenID(const std::optional<siz
 
 BreakupBuilder &BreakupBuilder::setIDFilter(const std::optional<std::set<size_t>> &idFilter) {
     _idFilter = idFilter;
+    return *this;
+}
+
+BreakupBuilder &BreakupBuilder::setEnforceMassConservation(bool enforceMassConservation) {
+    _enforceMassConservation = enforceMassConservation;
     return *this;
 }
 
@@ -95,11 +101,11 @@ std::unique_ptr<Breakup> BreakupBuilder::getBreakup() const {
 }
 
 std::unique_ptr<Breakup> BreakupBuilder::createExplosion(std::vector<Satellite> &satelliteVector, size_t maxID) const {
-    return std::make_unique<Explosion>(satelliteVector, _minimalCharacteristicLength, maxID);
+    return std::make_unique<Explosion>(satelliteVector, _minimalCharacteristicLength, maxID, _enforceMassConservation);
 }
 
 std::unique_ptr<Breakup> BreakupBuilder::createCollision(std::vector<Satellite> &satelliteVector, size_t maxID) const {
-    return std::make_unique<Collision>(satelliteVector, _minimalCharacteristicLength, maxID);
+    return std::make_unique<Collision>(satelliteVector, _minimalCharacteristicLength, maxID, _enforceMassConservation);
 }
 
 std::vector<Satellite> BreakupBuilder::applyFilter() const {

--- a/src/breakupModel/simulation/BreakupBuilder.h
+++ b/src/breakupModel/simulation/BreakupBuilder.h
@@ -29,6 +29,8 @@ class BreakupBuilder {
 
     std::vector<Satellite> _satellites;
 
+    bool _enforceMassConservation;
+
 public:
 
     explicit BreakupBuilder(const std::shared_ptr<InputConfigurationSource> &configurationSource)
@@ -37,6 +39,7 @@ public:
               _simulationType{configurationSource->getTypeOfSimulation()},
               _currentMaximalGivenID{configurationSource->getCurrentMaximalGivenID()},
               _idFilter{configurationSource->getIDFilter()},
+              _enforceMassConservation{configurationSource->getEnforceMassConservation()},
               _satellites{configurationSource->getDataReader()->getSatelliteCollection()} {}
 
     /**
@@ -81,6 +84,13 @@ public:
      * @return this
      */
     BreakupBuilder &setIDFilter(const std::optional<std::set<size_t>> &idFilter);
+
+    /**
+     * Overrides/ Re-Sets the value of enforceMassConservation to the given value.
+     * @param enforceMassConservation - new Value
+     * @return this
+     */
+    BreakupBuilder &setEnforceMassConservation(bool enforceMassConservation);
 
     /**
      * Overrides/ Re-Sets the Data Source to a specific Satellite vector

--- a/src/breakupModel/simulation/Collision.cpp
+++ b/src/breakupModel/simulation/Collision.cpp
@@ -16,7 +16,7 @@ void Collision::calculateFragmentCount() {
     //Sets the maximalCharacteristicLength which will be required later
     _maximalCharacteristicLength = std::max(sat1.getCharacteristicLength(), sat2.getCharacteristicLength());
 
-    //Sets the _satType attribute to the correct type (later required for the A/M)
+    //Sets the satType attribute to the correct type (later required for the A/M)
     //The Default of this member is SPACECRAFT
     if (sat1.getSatType() == SatType::ROCKET_BODY || sat2.getSatType() == SatType::ROCKET_BODY) {
         _satType = SatType::ROCKET_BODY;

--- a/src/breakupModel/simulation/Collision.cpp
+++ b/src/breakupModel/simulation/Collision.cpp
@@ -29,6 +29,12 @@ void Collision::calculateFragmentCount() {
         std::swap(sat1, sat2);
     }
 
+    //Sets the _input mass which will be required later for mass conservation purpose (maximal upper bound)
+    _inputMass = sat1.getMass() + sat2.getMass();
+
+    //Contains the mass M (later filled with an adequate value)
+    double mass = 0;
+
     //The Relative Collision Velocity
     double dv = euclideanNorm(sat1.getVelocity() - sat2.getVelocity());
 
@@ -39,14 +45,14 @@ void Collision::calculateFragmentCount() {
     if (catastrophicRatio < 40.0) {
         _isCatastrophic = false;
         //The paper states this as product of the projectile's mass in [kg] and the collision velocity in [km/s]
-        _inputMass = sat2.getMass() * dv / 1000.0;
+        mass = sat2.getMass() * dv / 1000.0;
     } else {
         _isCatastrophic = true;
-        _inputMass = sat1.getMass() + sat2.getMass();
+        mass = sat1.getMass() + sat2.getMass();
     }
 
     //The fragment Count, respectively Equation 4
-    auto fragmentCount = static_cast<size_t>(0.1 * std::pow(_inputMass, 0.75) *
+    auto fragmentCount = static_cast<size_t>(0.1 * std::pow(mass, 0.75) *
                                              std::pow(_minimalCharacteristicLength, -1.71));
     this->generateFragments(fragmentCount, sat1.getPosition());
 }

--- a/src/breakupModel/simulation/Collision.cpp
+++ b/src/breakupModel/simulation/Collision.cpp
@@ -69,10 +69,11 @@ void Collision::assignParentProperties() {
     std::for_each(tupleView.begin(), tupleView.end(),
                   [&](auto &tuple) {
         //Order in the tuple: 0: Characteristic Length | 1: Mass | 2: Velocity | 3: NamePtr
-        if (std::get<0>(tuple) > smallSat.getCharacteristicLength()) {
-            std::get<3>(tuple) = debrisNameBigPtr;
-            std::get<2>(tuple) = bigSat.getVelocity();
-            assignedMassForBigSatellite += std::get<1>(tuple);
+        auto &[lc, mass, velocity, name] = tuple;
+        if (lc > smallSat.getCharacteristicLength()) {
+            name = debrisNameBigPtr;
+            velocity = bigSat.getVelocity();
+            assignedMassForBigSatellite += mass;
         }
     });
 
@@ -83,14 +84,15 @@ void Collision::assignParentProperties() {
     std::for_each(tupleView.begin(), tupleView.end(),
                   [&](auto &tuple) {
         //Order in the tuple: 0: Characteristic Length | 1: Mass | 2: Velocity | 3: NamePtr
-        if (std::get<0>(tuple) <= smallSat.getCharacteristicLength()
+        auto &[lc, mass, velocity, name] = tuple;
+        if (lc <= smallSat.getCharacteristicLength()
         && assignedMassForBigSatellite < normedMassBigSat) {
-            std::get<3>(tuple) = debrisNameBigPtr;
-            std::get<2>(tuple) = bigSat.getVelocity();
-            assignedMassForBigSatellite += std::get<1>(tuple);
+            name = debrisNameBigPtr;
+            velocity = bigSat.getVelocity();
+            assignedMassForBigSatellite += mass;
         } else {
-            std::get<3>(tuple) = debrisNameSmallPtr;
-            std::get<2>(tuple) = smallSat.getVelocity();
+            name = debrisNameSmallPtr;
+            velocity = smallSat.getVelocity();
         }
     });
 }

--- a/src/breakupModel/simulation/Collision.cpp
+++ b/src/breakupModel/simulation/Collision.cpp
@@ -1,5 +1,12 @@
 #include "Collision.h"
 
+void Collision::init() {
+    //The pdf for Collisions is: 0.0101914/(x^2.71)
+    _lcPowerLawExponent = -2.71;
+    //Equation 12 mu = 0.9 * chi + 2.9
+    _deltaVelocityFactorOffset = std::make_pair(0.9, 2.9);
+}
+
 void Collision::calculateFragmentCount() {
     using util::operator-, util::euclideanNorm;
     //Get the two satellites from the input
@@ -47,11 +54,6 @@ void Collision::calculateFragmentCount() {
     this->generateFragments(fragmentCount, sat1.getPosition());
 }
 
-void Collision::characteristicLengthDistribution() {
-    //The pdf for Collisions is: 0.0101914/(x^2.71)
-    Breakup::characteristicLengthDistribution(-2.71);
-}
-
 void Collision::assignParentProperties() {
     //The names of the fragments for a given parent
     const Satellite &bigSat = _input.at(0);
@@ -91,9 +93,4 @@ void Collision::assignParentProperties() {
             std::get<2>(tuple) = smallSat.getVelocity();
         }
     });
-}
-
-void Collision::deltaVelocityDistribution() {
-    //Equation 12 mu = 0.9 * chi + 2.9
-    Breakup::deltaVelocityDistribution(0.9, 2.9);
 }

--- a/src/breakupModel/simulation/Collision.cpp
+++ b/src/breakupModel/simulation/Collision.cpp
@@ -1,6 +1,7 @@
 #include "Collision.h"
 
 void Collision::init() {
+    Breakup::init();
     //The pdf for Collisions is: 0.0101914/(x^2.71)
     _lcPowerLawExponent = -2.71;
     //Equation 12 mu = 0.9 * chi + 2.9

--- a/src/breakupModel/simulation/Collision.h
+++ b/src/breakupModel/simulation/Collision.h
@@ -16,11 +16,11 @@ public:
 
 private:
 
-    void init() override;
+    void init() final;
 
-    void calculateFragmentCount() override;
+    void calculateFragmentCount() final;
 
-    void assignParentProperties() override;
+    void assignParentProperties() final;
 
 public:
 

--- a/src/breakupModel/simulation/Collision.h
+++ b/src/breakupModel/simulation/Collision.h
@@ -15,13 +15,12 @@ public:
     using Breakup::Breakup;
 
 private:
+
+    void init() override;
+
     void calculateFragmentCount() override;
 
-    void characteristicLengthDistribution() override;
-
     void assignParentProperties() override;
-
-    void deltaVelocityDistribution() override;
 
 public:
 

--- a/src/breakupModel/simulation/Explosion.cpp
+++ b/src/breakupModel/simulation/Explosion.cpp
@@ -2,6 +2,7 @@
 #include "Breakup.h"
 
 void Explosion::init() {
+    Breakup::init();
     //The pdf for Explosions is: 0.0132578/x^2.6
     _lcPowerLawExponent = -2.6;
     //Equation 11 mu = 0.2 * chi + 1.85

--- a/src/breakupModel/simulation/Explosion.cpp
+++ b/src/breakupModel/simulation/Explosion.cpp
@@ -15,7 +15,7 @@ void Explosion::calculateFragmentCount() {
     //Sets the maximalCharacteristicLength which will be required later
     _maximalCharacteristicLength = sat.getCharacteristicLength();
 
-    //Sets the _satType attribute to the correct type (later required for the A/M)
+    //Sets the satType attribute to the correct type (later required for the A/M)
     //The Default of this member is SPACECRAFT
     _satType = sat.getSatType();
 

--- a/src/breakupModel/simulation/Explosion.cpp
+++ b/src/breakupModel/simulation/Explosion.cpp
@@ -1,6 +1,13 @@
 #include "Explosion.h"
 #include "Breakup.h"
 
+void Explosion::init() {
+    //The pdf for Explosions is: 0.0132578/x^2.6
+    _lcPowerLawExponent = -2.6;
+    //Equation 11 mu = 0.2 * chi + 1.85
+    _deltaVelocityFactorOffset = std::make_pair(0.2, 1.85);
+}
+
 void Explosion::calculateFragmentCount() {
     //Gets the one satellite from the input
     Satellite &sat = _input.at(0);
@@ -20,11 +27,6 @@ void Explosion::calculateFragmentCount() {
     this->generateFragments(fragmentCount, sat.getPosition());
 }
 
-void Explosion::characteristicLengthDistribution() {
-    //The pdf for Explosions is: 0.0132578/x^2.6
-    Breakup::characteristicLengthDistribution(-2.6);
-}
-
 void Explosion::assignParentProperties() {
     //The name of the fragments
     const Satellite &parent = _input.at(0);
@@ -37,9 +39,4 @@ void Explosion::assignParentProperties() {
         std::get<0>(tuple) = parent.getVelocity();
         std::get<1>(tuple) = debrisNamePtr;
     });
-}
-
-void Explosion::deltaVelocityDistribution() {
-    //Equation 11 mu = 0.2 * chi + 1.85
-    Breakup::deltaVelocityDistribution(0.2, 1.85);
 }

--- a/src/breakupModel/simulation/Explosion.cpp
+++ b/src/breakupModel/simulation/Explosion.cpp
@@ -36,7 +36,8 @@ void Explosion::assignParentProperties() {
     std::for_each(std::execution::par, tupleView.begin(), tupleView.end(),
                   [&](auto &tuple) {
         //Order in the tuple: 0: Velocity | 1: NamePtr
-        std::get<0>(tuple) = parent.getVelocity();
-        std::get<1>(tuple) = debrisNamePtr;
+        auto &[velocity, name] = tuple;
+        velocity = parent.getVelocity();
+        name = debrisNamePtr;
     });
 }

--- a/src/breakupModel/simulation/Explosion.h
+++ b/src/breakupModel/simulation/Explosion.h
@@ -13,11 +13,11 @@ public:
 
 private:
 
-    void init() override;
+    void init() final;
 
-    void calculateFragmentCount() override;
+    void calculateFragmentCount() final;
 
-    void assignParentProperties() override;
+    void assignParentProperties() final;
 
 };
 

--- a/src/breakupModel/simulation/Explosion.h
+++ b/src/breakupModel/simulation/Explosion.h
@@ -12,13 +12,12 @@ public:
     using Breakup::Breakup;
 
 private:
+
+    void init() override;
+
     void calculateFragmentCount() override;
 
-    void characteristicLengthDistribution() override;
-
     void assignParentProperties() override;
-
-    void deltaVelocityDistribution() override;
 
 };
 

--- a/src/breakupModel/util/UtilityAreaMassRatio.h
+++ b/src/breakupModel/util/UtilityAreaMassRatio.h
@@ -34,9 +34,9 @@ namespace util {
      */
     inline double alpha(SatType satType, double logLc) {
         return satType == SatType::ROCKET_BODY
-               ? distributionConstant(logLc, -1.4, 0, 1, 0.5,
+               ? distributionConstant(logLc, -1.4, 0.0, 1.0, 0.5,
                                       [](double logLc) { return 1.0 - 0.3571 * (logLc + 1.4); })
-               : distributionConstant(logLc, -1.95, 0.55, 0, 1,
+               : distributionConstant(logLc, -1.95, 0.55, 0.0, 1.0,
                                       [](double logLc) { return 0.3 + 0.4 * (logLc + 1.2); });
     }
 
@@ -47,9 +47,9 @@ namespace util {
     */
     inline double mu_1(SatType satType, double logLc) {
         return satType == SatType::ROCKET_BODY
-               ? distributionConstant(logLc, -0.5, 0, -0.45, -0.9,
+               ? distributionConstant(logLc, -0.5, 0.0, -0.45, -0.9,
                                       [](double logLc) { return -0.45 - 0.9 * (logLc + 0.5); })
-               : distributionConstant(logLc, -1.1, 0, -0.6, -0.95,
+               : distributionConstant(logLc, -1.1, 0.0, -0.6, -0.95,
                                       [](double logLc) { return -0.6 - 0.318 * (logLc + 1.1); });
     }
 

--- a/src/breakupModel/util/UtilityFunctions.h
+++ b/src/breakupModel/util/UtilityFunctions.h
@@ -76,7 +76,7 @@ namespace util {
     inline double calculateCharacteristicLengthFromMass(double mass) {
         static constexpr double Mul92_937PI = 92.937 * PI;
         static constexpr double Inv2_26 = 1.0 / 2.26;
-        return std::pow((6 * mass) / (Mul92_937PI), Inv2_26);
+        return std::pow((6.0 * mass) / (Mul92_937PI), Inv2_26);
     }
 
     /**
@@ -91,8 +91,8 @@ namespace util {
      * @return the transformed x following the power law distribution
      */
     inline double transformUniformToPowerLaw(double x0, double x1, double n, double y) {
-        double step = (std::pow(x1, n+1) - std::pow(x0, n+1)) * y + std::pow(x0, n+1);
-        return std::pow(step, 1/ (n + 1) );
+        double step = (std::pow(x1, n + 1.0) - std::pow(x0, n + 1.0)) * y + std::pow(x0, n + 1.0);
+        return std::pow(step, 1.0 / (n + 1.0));
     }
 
     /**

--- a/src/breakupModel/util/UtilityKepler.h
+++ b/src/breakupModel/util/UtilityKepler.h
@@ -29,7 +29,7 @@ namespace util {
         }
 
         inline double d_kepE(double EA, double eccentricity) {
-            return (1 - eccentricity * std::cos(EA));
+            return (1.0 - eccentricity * std::cos(EA));
         }
 
         inline double newtonRaphson(double EA, double MA, double e) {
@@ -52,7 +52,7 @@ namespace util {
          * @return angle in [rad], positive
          */
         inline double normAngle(double angle) {
-            return angle < 0 ? angle + PI2 : angle;
+            return angle < 0.0 ? angle + PI2 : angle;
         }
 
     }
@@ -88,7 +88,7 @@ namespace util {
      */
     inline double trueAnomalyToEccentricAnomaly(double TA, double e) {
         using namespace detail;
-        return normAngle(2 * std::atan(std::sqrt((1 - e) / (1 + e)) * std::tan(TA / 2)));
+        return normAngle(2.0 * std::atan(std::sqrt((1.0 - e) / (1.0 + e)) * std::tan(TA / 2.0)));
     }
 
     /**
@@ -99,7 +99,7 @@ namespace util {
      */
     inline double eccentricAnomalyToTrueAnomaly(double EA, double e) {
         using namespace detail;
-        return normAngle(2 * std::atan(std::sqrt((1 + e) / (1 - e)) * std::tan(EA / 2)));
+        return normAngle(2.0 * std::atan(std::sqrt((1.0 + e) / (1.0 - e)) * std::tan(EA / 2.0)));
     }
 
     /**

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,6 +13,9 @@
 
 int main(int argc, char *argv[]) {
 
+    //Enable to get debug messages
+    //spdlog::default_logger()->set_level(spdlog::level::debug);
+
     if (argc != 2) {
         spdlog::error(
                 "Wrong program call. Please call the program in the following way:\n"

--- a/test/model/OrbitalElementsTest.cpp
+++ b/test/model/OrbitalElementsTest.cpp
@@ -55,3 +55,45 @@ TEST(OrbitalElementsTest, OrbitalElements02) {
     ASSERT_DOUBLE_EQ(expectedTrueAnomaly, actualOrbitalElements.getAnomaly(AngularUnit::DEGREE));
 
 }
+
+TEST(OrbitalElementsTest, Epoch01) {
+    Epoch epoch{2016, 031.25992506};
+    std::tm actualTm = epoch.toTm();
+    std::tm expectedTm {};
+    expectedTm.tm_sec = 17;
+    expectedTm.tm_min = 14;
+    expectedTm.tm_hour = 6;
+    expectedTm.tm_mday = 31;
+    expectedTm.tm_mon = 0;
+    expectedTm.tm_yday = 31;
+    expectedTm.tm_year = 2016;
+
+    EXPECT_EQ(actualTm.tm_sec, expectedTm.tm_sec);
+    EXPECT_EQ(actualTm.tm_min, expectedTm.tm_min);
+    EXPECT_EQ(actualTm.tm_hour, expectedTm.tm_hour);
+    EXPECT_EQ(actualTm.tm_mday, expectedTm.tm_mday);
+    EXPECT_EQ(actualTm.tm_mon, expectedTm.tm_mon);
+    EXPECT_EQ(actualTm.tm_yday, expectedTm.tm_yday);
+    EXPECT_EQ(actualTm.tm_year, expectedTm.tm_year);
+}
+
+TEST(OrbitalElementsTest, Epoch02) {
+    Epoch epoch{2006, 040.85138889};
+    std::tm actualTm = epoch.toTm();
+    std::tm expectedTm {};
+    expectedTm.tm_sec = 0;
+    expectedTm.tm_min = 26;
+    expectedTm.tm_hour = 20;
+    expectedTm.tm_mday = 9;
+    expectedTm.tm_mon = 1;
+    expectedTm.tm_yday = 40;
+    expectedTm.tm_year = 2006;
+
+    EXPECT_EQ(actualTm.tm_sec, expectedTm.tm_sec);
+    EXPECT_EQ(actualTm.tm_min, expectedTm.tm_min);
+    EXPECT_EQ(actualTm.tm_hour, expectedTm.tm_hour);
+    EXPECT_EQ(actualTm.tm_mday, expectedTm.tm_mday);
+    EXPECT_EQ(actualTm.tm_mon, expectedTm.tm_mon);
+    EXPECT_EQ(actualTm.tm_yday, expectedTm.tm_yday);
+    EXPECT_EQ(actualTm.tm_year, expectedTm.tm_year);
+}

--- a/test/output/VTKWriterTest.cpp
+++ b/test/output/VTKWriterTest.cpp
@@ -17,6 +17,7 @@ protected:
             Satellite satellite{i};
             satellite.setPosition({d, d, d});
             satellite.setVelocity({d, d, d});
+            satellite.setEjectionVelocity({d*100, d, d});
             satellite.setMass(d * 10);
             satellite.setCharacteristicLength(d * 100);
             _satelliteCollection.push_back(satellite);
@@ -66,5 +67,5 @@ TEST_F(VTKWriterTest, DataCheck) {
         ASSERT_EQ(actualLine, expectedLine) << "The error was in line " << actualLineNumber;
         actualLineNumber += 1;
     }
-    ASSERT_EQ(actualLineNumber, 52);
+    ASSERT_EQ(actualLineNumber, 58);
 }

--- a/test/resources/VTKWriterTest.vtu
+++ b/test/resources/VTKWriterTest.vtu
@@ -33,6 +33,12 @@
           3 3 3
           4 4 4
         </DataArray>
+        <DataArray Name="ejection-velocity" NumberOfComponents="3" format="ascii" type="Float32">
+          100 1 1
+          200 2 2
+          300 3 3
+          400 4 4
+        </DataArray>
       </PointData>
       <CellData/>
       <Points>

--- a/test/simulation/CollisionTest.cpp
+++ b/test/simulation/CollisionTest.cpp
@@ -100,15 +100,15 @@ TEST_F(CollisionTest, CheckNoRaceCondition) {
         size_t count = 0;
         _collision->run();
         auto output = _collision->getResultSoA();
-        for (double lc1 : output._characteristicLength) {
-            for (double lc2 : output._characteristicLength) {
+        for (double lc1 : output.characteristicLength) {
+            for (double lc2 : output.characteristicLength) {
                 bool condition = std::abs(lc1 - lc2) < 1e-16;
                 if (condition) {
                     count += 1;
                 }
             }
         }
-        count -= output._characteristicLength.size();
+        count -= output.characteristicLength.size();
         //10 is threshold
         //If we would have race conditions, it can be assumed that there are a lot more than 10 duplicates
         EXPECT_LT(count, 10) << "Count of Duplicates in Iteration " << x << "\n"

--- a/test/simulation/ExplosionTest.cpp
+++ b/test/simulation/ExplosionTest.cpp
@@ -85,15 +85,15 @@ TEST_F(ExplosionTest, CheckNoRaceCondition) {
         size_t count = 0;
         _explosion->run();
         auto output = _explosion->getResultSoA();
-        for (double lc1 : output._characteristicLength) {
-            for (double lc2 : output._characteristicLength) {
+        for (double lc1 : output.characteristicLength) {
+            for (double lc2 : output.characteristicLength) {
                 bool condition = std::abs(lc1 - lc2) < 1e-16;
                 if (condition) {
                     count += 1;
                 }
             }
         }
-        count -= output._characteristicLength.size();
+        count -= output.characteristicLength.size();
         //10 is threshold
         //If we would have race conditions, it can be assumed that there are a lot more than 10 duplicates
         EXPECT_LT(count, 10) << "Count of Duplicates in Iteration " << x << "\n"


### PR DESCRIPTION
## Content

- Added an option to the YAML file to enable Mass Conservation
- Details, see README.md
- resolves #39 
-----------------------------

- The TLEReader does now read in the Epoche (Line 1 had to be added)
- There is a new structure Epoch which contains two members: year + fraction (of the year/ of the day)
  - I decided to implement this structure in order to save memory (one double + one int is a lot less than the whole structure from ``<ctime>`` or ``<chrono>``
  - It has a method to convert to a ``tm`` instance (from ``<ctime>``)
- The Epoch can contain negative values in which case it is not present/ invalid (again to save the overhead of a std::optional)
- The Epoch is a member of the OrbitalElements Class
- This resolves #40 

## Notice
This PR builds on top of the Pull Requests:
- #38
- #41  (Closed because it builds in on top of #38, but the improvements are made in #42)